### PR TITLE
Add test framework with distance calculation unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "running",
+  "version": "1.0.0",
+  "description": "run",
+  "main": "service-worker.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "chai": "^5.2.1",
+    "mocha": "^11.7.1"
+  }
+}

--- a/test/calculateDistance.test.js
+++ b/test/calculateDistance.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const { expect } = require('chai');
+
+const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+const match = html.match(/function\s+calculateDistance\([^)]*\)\s*{[\s\S]*?}/);
+if (!match) {
+  throw new Error('calculateDistance function not found in index.html');
+}
+// Evaluate the function definition to make calculateDistance available
+// eslint-disable-next-line no-eval
+eval(match[0]);
+
+describe('calculateDistance', () => {
+  it('returns distance between Paris and London within tolerance', () => {
+    const paris = { lat: 48.8566, lon: 2.3522 };
+    const london = { lat: 51.5074, lon: -0.1278 };
+    const result = calculateDistance(paris.lat, paris.lon, london.lat, london.lon);
+    expect(result).to.be.closeTo(343556, 1000); // ~343 km
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha and chai with npm
- ignore node_modules and lock file
- provide unit test for `calculateDistance` using values from Paris to London

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c3db031bc832bb8ca16cb57f62a67