### PR TITLE
Remove missing assets from service-worker cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -6,8 +6,6 @@ const urlsToCache = [
   '/',
   '/index.html',
   '/manifest.json',
-  '/css/styles.css',
-  '/js/app.js',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/webfonts/fa-solid-900.woff2',
   'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css',


### PR DESCRIPTION
## Summary
- stop caching missing `/css/styles.css` and `/js/app.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c3d969430832b88d25b1f1a391dc9