### PR TITLE
Fix voice feedback typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2186,7 +2186,7 @@ function updateIntervalIndicator() {
                 
                 // Instruction vocale si nécessaire
                 if (userData.voiceEnabled && currentDuration - lastSpokenTime > 60) {
-                    const utterance = new SpeechSynthesisUtterance("Accélérez fénéasse, vous êtes trop lent.");
+                    const utterance = new SpeechSynthesisUtterance("Accélérez feignasse, vous êtes trop lent.");
                     utterance.lang = 'fr-FR';
                     speechSynthesis.speak(utterance);
                     lastSpokenTime = currentDuration;


### PR DESCRIPTION
## Summary
- correct the spelling of "feignasse" in voice feedback

## Testing
- `grep -n "feignasse" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_687c3d85d498832bb008c938ef33cc22