### PR TITLE
Handle background page changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RunPacer is a lightweight web app that helps you track your running sessions and
 2. Open `index.html` in your web browser.
 3. Allow the app to access your location if you want to record GPS tracks.
 
-Your runs are stored locally in the browser. You can view statistics, generate training plans and share your progress. A Strava integration lets you publish your activities directly if you provide a personal access token. The service worker enables offline access so the app can be installed as a Progressive Web App.
+Your runs are stored locally in the browser. You can view statistics, generate training plans and share your progress. A Strava integration lets you publish your activities directly if you provide a personal access token. The service worker enables offline access so the app can be installed as a Progressive Web App. Background data saving keeps a run active even when you switch pages or open other apps.
 
 ```
 # Example

--- a/index.html
+++ b/index.html
@@ -2393,9 +2393,10 @@ function updateIntervalIndicator() {
 }
 
         // Stocker les données de course périodiquement
-function storeRunDataPeriodically() {
+// Sauvegarder les données de course une fois
+function storeRunData() {
     if (!isRunning) return;
-    
+
     const runData = {
         startTime: new Date().getTime() - (currentDuration * 1000),
         currentDuration: currentDuration,
@@ -2405,17 +2406,20 @@ function storeRunDataPeriodically() {
         runType: currentRunType,
         targetPace: currentTargetPace
     };
-    
+
     localStorage.setItem('currentRunData', JSON.stringify(runData));
-    
-    // Envoyer au Service Worker
+
     if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
         navigator.serviceWorker.controller.postMessage({
             type: 'UPDATE_BACKGROUND_RUN',
             runData: runData
         });
     }
-    
+}
+
+// Stocker les données de course périodiquement
+function storeRunDataPeriodically() {
+    storeRunData();
     setTimeout(storeRunDataPeriodically, 10000); // Toutes les 10 secondes
 }
 
@@ -2529,6 +2533,7 @@ document.addEventListener('visibilitychange', () => {
     // L'application passe en arrière-plan
     if (isRunning) {
       isBackgroundRun = true;
+      storeRunData();
       console.log('Application en arrière-plan, suivi continu');
     }
   } else {
@@ -2536,6 +2541,18 @@ document.addEventListener('visibilitychange', () => {
     handleAppResume();
   }
 });
+
+// Sauvegarder lorsqu'on quitte la page
+window.addEventListener('pagehide', () => {
+  if (isRunning) {
+    storeRunData();
+    isBackgroundRun = true;
+    console.log('Données sauvegardées avant de quitter la page');
+  }
+});
+
+// Reprendre après retour sur la page
+window.addEventListener('pageshow', handleAppResume);
 
 // Sauvegarder automatiquement le plan d'entraînement
 function saveTrainingPlan() {


### PR DESCRIPTION
## Summary
- retain run data when leaving or returning to the page
- explain background saving in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c5212e358832ba1dafc20b9b00ef6