### PR TITLE
Fix resume bug causing duplicate timers

### DIFF
--- a/index.html
+++ b/index.html
@@ -2477,10 +2477,15 @@ function handleAppResume() {
         type: 'GET_BACKGROUND_RUN'
       });
     }
-    
-    // Redémarrer le suivi
+
+    // Reprendre le suivi sans réinitialiser
     isBackgroundRun = false;
-    startRun();
+    if (!runInterval) {
+      runInterval = setInterval(updateRunningTime, 1000);
+    }
+    if (!isTrackingLocation) {
+      startGpsTracking();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- when returning from background, don't call `startRun`
- resume existing timer and GPS tracking if needed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c57447500832b8a4e6ddc329d2424