### PR TITLE
Add animated splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,9 +582,78 @@
         #run-detail-section.active {
             display: block;
         }
+
+        /* Écran d'accueil animé */
+        #splash-screen {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: white;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            z-index: 2000;
+        }
+
+        #splash-screen.fade-out {
+            opacity: 0;
+            transition: opacity 0.5s ease;
+            pointer-events: none;
+        }
+
+        .runner-icon {
+            font-size: 3rem;
+            color: var(--primary-color);
+            animation: runMove 2s ease-in-out forwards;
+        }
+
+        .runner-track {
+            width: 120px;
+            height: 4px;
+            background-color: var(--light-color);
+            border-radius: 2px;
+            overflow: hidden;
+            margin-top: 8px;
+            position: relative;
+        }
+
+        .runner-track::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 0;
+            background-color: var(--secondary-color);
+            animation: trackDraw 2s forwards;
+        }
+
+        .splash-logo {
+            font-size: 2rem;
+            margin-top: 20px;
+            color: var(--dark-color);
+        }
+
+        @keyframes runMove {
+            from { transform: translateX(-40px); }
+            to { transform: translateX(40px); }
+        }
+
+        @keyframes trackDraw {
+            from { width: 0; }
+            to { width: 100%; }
+        }
     </style>
 </head>
 <body>
+    <div id="splash-screen">
+        <i class="fas fa-running runner-icon"></i>
+        <div class="runner-track"></div>
+        <div class="splash-logo">RunPacer</div>
+    </div>
     <header>
         <button id="theme-toggle" title="Changer de thème"><i class="fas fa-moon"></i></button>
         <h1>RunPacer</h1>
@@ -2999,6 +3068,17 @@ function loadTrainingPlan() {
                 alert('Erreur Strava: ' + err.message);
             }
         }
+
+        // Disparition de l'écran d'accueil après chargement
+        window.addEventListener('load', function() {
+            const splash = document.getElementById('splash-screen');
+            if (splash) {
+                setTimeout(() => {
+                    splash.classList.add('fade-out');
+                    setTimeout(() => splash.remove(), 600);
+                }, 1500);
+            }
+        });
     </script>
     <footer><a href="PRIVACY.md">Politique de confidentialite</a></footer>
 </body>


### PR DESCRIPTION
## Summary
- add a small animated splash screen with a runner icon and track line
- hide splash screen after load for a smooth transition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cfce98300832bb6be205188f68263