### PR TITLE
Fix horizontal scroll on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
             padding: var(--spacing);
             margin-bottom: var(--spacing);
             box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+            overflow-x: auto; /* Avoid page overflow on small screens */
         }
         
         .card-title {
@@ -454,6 +455,12 @@
             transition: height 0.5s ease;
         }
 
+        /* Ensure the pace chart doesn't overflow horizontally */
+        #pace-chart {
+            width: 100%;
+            height: auto;
+        }
+
         /* Styles pour les courses dans la liste d'historique */
         #history-table tr {
             transition: background-color 0.2s ease;
@@ -528,10 +535,15 @@
 .progress-container {
     margin-bottom: 8px;
 }
-#goal-progress {
-    width: 100%;
-    height: 12px;
-}
+        #goal-progress {
+            width: 100%;
+            height: 12px;
+        }
+
+        /* Allow horizontal scrolling for wide plan tables */
+        #full-plan-container {
+            overflow-x: auto;
+        }
 
         
         /* Styles pour les statistiques d'élévation */


### PR DESCRIPTION
## Summary
- avoid page overflow by letting cards scroll horizontally
- ensure pace chart scales to mobile screens
- allow plan table container to scroll horizontally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e5423ed9c832b8527b7251a05d7ed