### PR TITLE
Fix PWA start path

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "RunPacer",
   "short_name": "RunPacer",
-  "start_url": "/index.html",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#3498db",
   "theme_color": "#3498db",

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,9 +3,9 @@ const CACHE_NAME = 'runpacer-cache-v3';
 
 // Fichiers à mettre en cache
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/manifest.json',
+  './',
+  'index.html',
+  'manifest.json',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/webfonts/fa-solid-900.woff2',
   'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css',


### PR DESCRIPTION
## Summary
- update `start_url` in manifest.json for relative path
- use relative URLs in service worker cache list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e9e5cfa5c832baee8c47b51a2abb6