### PR TITLE
Assure mobile charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,6 +466,14 @@
             height: auto;
         }
 
+        /* Ensure other charts scale on small screens */
+        #weekly-distance-chart,
+        #speed-histogram-chart,
+        #monthly-goal-chart {
+            width: 100%;
+            height: auto;
+        }
+
         /* Styles pour les courses dans la liste d'historique */
         #history-table tr {
             transition: background-color 0.2s ease;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Nom du cache
-const CACHE_NAME = 'runpacer-cache-v3';
+const CACHE_NAME = 'runpacer-cache-v4';
 
 // Fichiers à mettre en cache
 const urlsToCache = [
@@ -11,7 +11,8 @@ const urlsToCache = [
   'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css',
   'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js',
   'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-  'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png'
+  'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+  'https://cdn.jsdelivr.net/npm/chart.js'
 ];
 
 // Installation du service worker


### PR DESCRIPTION
## Summary
- ensure progression charts adapt on mobile screens
- cache Chart.js in the service worker for offline access

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ea4440428832b99ec214038a0c1e3