### PR TITLE
Confirm run start from plan and calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1684,12 +1684,19 @@ document.getElementById('plan-event-date').min = new Date(new Date().getTime() +
 function startSelectedSession(sessionIndex) {
     const session = userData.trainingPlan[sessionIndex];
 
+    if (!session) return;
+
     if (session.completed) {
         const runIndex = userData.runs.findIndex(r => r.date === session.date && r.type === session.type);
         if (runIndex !== -1) {
             showRunDetails(runIndex);
             return;
         }
+    }
+
+    const confirmMsg = `D\u00e9marrer la s\u00e9ance du ${new Date(session.date).toLocaleDateString('fr-FR')} ?`;
+    if (!confirm(confirmMsg)) {
+        return;
     }
 
     // Retirer la sélection précédente
@@ -1771,7 +1778,8 @@ function renderTrainingCalendar() {
     }
     for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
         const dateStr = d.toISOString().split('T')[0];
-        const session = userData.trainingPlan.find(s => s.date === dateStr);
+        const sessionIndex = userData.trainingPlan.findIndex(s => s.date === dateStr);
+        const session = userData.trainingPlan[sessionIndex];
         let icon = '😴';
         let cls = 'session-rest';
         if (session) {
@@ -1790,6 +1798,22 @@ function renderTrainingCalendar() {
         }
         const star = session && session.completed ? '<span class="done-star">⭐</span>' : '';
         cell.innerHTML = `<span class="session-icon ${cls}">${icon}</span>${d.getDate()}${star}`;
+        if (session) {
+            if (session.completed) {
+                const runIndex = userData.runs.findIndex(r => r.date === session.date && r.type === session.type);
+                if (runIndex !== -1) {
+                    cell.addEventListener('click', () => showRunDetails(runIndex));
+                }
+            } else {
+                cell.addEventListener('click', () => {
+                    startSelectedSession(sessionIndex);
+                });
+            }
+        } else {
+            cell.addEventListener('click', () => {
+                alert("Bon repos ! Le repos est essentiel pour progresser.");
+            });
+        }
         cal.appendChild(cell);
     }
 }


### PR DESCRIPTION
## Summary
- add confirmation dialog before starting a session
- wire up calendar cells to start or show sessions
- display a rest message when clicking on rest days

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eaa2a6b5c832b8a1c3b5ee21813bb