### PR TITLE
Fix interval distance update

### DIFF
--- a/index.html
+++ b/index.html
@@ -2585,7 +2585,7 @@ function updateGoalProgress() {
                 const speedMps = segmentDistance / timeElapsed;
                 
                 // Ignorer les points aberrants (vitesse > 10 m/s ou 36 km/h)
-                if (segmentDistance > 1 && speedMps < 10) {
+                if (segmentDistance > 0 && speedMps < 10) {
         distanceTraveled += segmentDistance;
         
         // Gestion spécifique des intervalles
@@ -2683,9 +2683,10 @@ function updateGoalProgress() {
                         updatePaceFeedback(currentPaceSeconds * 60); // Convertir en secondes
                     }
                     
-                    // Mettre à jour la carte
-                    updateMap(latitude, longitude);
+                    // Mettre à jour la carte dans tous les cas plus bas
                 }
+                // Mise à jour de la carte même si le segment est très court
+                updateMap(latitude, longitude);
             } else {
                 // Premier point, initialiser la carte
                 updateMap(latitude, longitude);


### PR DESCRIPTION
## Summary
- improve interval countdown by removing 1m threshold
- always update the map when receiving GPS data

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd54aa710832b87f03f395671fe55