### PR TITLE
Add race countdown overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,23 @@
             box-shadow: 0 2px 5px rgba(0,0,0,0.2);
             animation: pulse 2s infinite;
         }
+
+        /* Compte à rebours avant la course */
+        #countdown-overlay {
+            position: fixed;
+            inset: 0;
+            background-color: rgba(0,0,0,0.7);
+            color: white;
+            display: none;
+            justify-content: center;
+            align-items: center;
+            font-size: 4rem;
+            z-index: 2200;
+        }
+
+        #countdown-overlay.active {
+            display: flex;
+        }
         
         @keyframes pulse {
             0% { transform: scale(1); opacity: 1; }
@@ -781,6 +798,7 @@
             <button class="btn" id="onboard-skip" style="margin-top:8px;">Je le ferai plus tard</button>
         </div>
     </div>
+    <div id="countdown-overlay"></div>
     <header>
         <button id="theme-toggle" title="Changer de thème"><i class="fas fa-moon"></i></button>
         <h1>RunPacer</h1>
@@ -1433,6 +1451,44 @@ const runTypes = {
                 return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
             }
         }
+
+        // Afficher un compte à rebours avant la course
+        function startCountdown(callback) {
+            const overlay = document.getElementById('countdown-overlay');
+            overlay.textContent = '3';
+            overlay.classList.add('active');
+            let count = 3;
+
+            if (userData.voiceEnabled) {
+                const utter = new SpeechSynthesisUtterance('3');
+                utter.lang = 'fr-FR';
+                speechSynthesis.speak(utter);
+            }
+
+            const interval = setInterval(() => {
+                count--;
+                if (count > 0) {
+                    overlay.textContent = count;
+                    if (userData.voiceEnabled) {
+                        const utter = new SpeechSynthesisUtterance(String(count));
+                        utter.lang = 'fr-FR';
+                        speechSynthesis.speak(utter);
+                    }
+                } else if (count === 0) {
+                    overlay.textContent = 'GO!';
+                    if (userData.voiceEnabled) {
+                        const utter = new SpeechSynthesisUtterance('Go');
+                        utter.lang = 'fr-FR';
+                        speechSynthesis.speak(utter);
+                    }
+                } else {
+                    clearInterval(interval);
+                    overlay.classList.remove('active');
+                    overlay.textContent = '';
+                    callback();
+                }
+            }, 1000);
+        }
         
     
 
@@ -1838,8 +1894,8 @@ function startSelectedSession(sessionIndex) {
     // Mettre à jour l'affichage du rythme cible
     document.getElementById('target-pace').textContent = session.pace;
     
-    // Démarrer la course
-    startRun();
+    // Démarrer la course après un compte à rebours
+    startCountdown(() => startRun());
 }
         
         // Mettre à jour l'affichage de la prochaine séance
@@ -2437,8 +2493,8 @@ function updateGoalProgress() {
             
             document.getElementById('target-pace').textContent = secondsToPace(targetPaceSeconds);
             
-            // Démarrer la simulation de course
-            startRun();
+            // Démarrer la simulation de course après un compte à rebours
+            startCountdown(() => startRun());
         });
         
         // Gestion du changement de type de course


### PR DESCRIPTION
## Summary
- add countdown overlay styles and DOM container
- implement `startCountdown` helper using speech synthesis when enabled
- trigger countdown before starting a run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd566ae84832baa333119ca963b36