### PR TITLE
Display version 1.12 on splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,6 +733,12 @@
             color: var(--dark-color);
         }
 
+        .splash-version {
+            font-size: 1rem;
+            margin-top: 8px;
+            color: var(--dark-color);
+        }
+
         @keyframes runMove {
             from { transform: translateX(-40px); }
             to { transform: translateX(40px); }
@@ -773,6 +779,7 @@
         <i class="fas fa-running runner-icon"></i>
         <div class="runner-track"></div>
         <div class="splash-logo">RunPacer</div>
+        <div class="splash-version">Version 1.12</div>
     </div>
     <div id="onboarding-overlay">
         <div class="onboarding-step" id="onboard-step-1">


### PR DESCRIPTION
## Summary
- Display version 1.12 on initial splash screen to show app version during loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924df88100832b8547149bd23de0a5