### PR TITLE
fix: ignore stop when no run

### DIFF
--- a/index.html
+++ b/index.html
@@ -3223,7 +3223,7 @@ function loadTrainingPlan() {
         
         // Fonction pour arrêter la course
         async function stopRun() {
-            if (!(isRunning || document.getElementById('pause-btn').innerHTML.includes('fa-play'))) {
+            if (!runStartTime) {
                 return;
             }
             clearInterval(runInterval);
@@ -3310,6 +3310,8 @@ function loadTrainingPlan() {
             document.getElementById('pause-btn').onclick = startRun;
             document.getElementById('stop-btn').disabled = true;
             document.getElementById('pace-feedback').textContent = "Prêt à commencer";
+            runStartTime = null;
+            runStartTimestamp = 0;
         }
 
         document.getElementById('stop-btn').addEventListener('click', stopRun);


### PR DESCRIPTION
## Summary
- prevent stopRun from running when no run has started
- reset run start values after stopping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689677afd3b4832b82df1391c803b1ae