### PR TITLE
Fix theme toggle position for iOS safe area

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,8 @@
         #theme-toggle {
             position: absolute;
             top: 10px;
+            top: calc(10px + constant(safe-area-inset-top));
+            top: calc(10px + env(safe-area-inset-top));
             right: 10px;
             background: none;
             border: none;


### PR DESCRIPTION
## Summary
- Offset theme toggle from top safe area to prevent overlap with iOS status bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896c4fc1a7c832b9abdb69102ef64de