### PR TITLE
feat: add postpartum training plan

### DIFF
--- a/postpartum.js
+++ b/postpartum.js
@@ -1,0 +1,115 @@
+/**
+ * Utilities for postpartum return-to-running plans.
+ * The implementation is intentionally simple and aims to respect
+ * safety rules: readiness evaluation, 48h rest, and <=15% weekly progression.
+ */
+
+// Helper to add days to a date
+function addDays(date, days) {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/**
+ * Evaluate readiness for running after pregnancy.
+ * @param {Object} pp - PostpartumProfile-like object
+ * @returns {"OK"|"DeferToWalkPelvic"|"Stop"}
+ */
+function evaluateReadiness(pp) {
+  const crit = pp.symptoms?.abnormalBleeding || pp.symptoms?.incisionPain;
+  if (crit) return "Stop";
+  const light = pp.symptoms?.leakage || pp.symptoms?.heaviness ||
+    pp.symptoms?.painAbdominalBack || pp.symptoms?.diastasisSuspected;
+  if (pp.weeksPostpartum < 12 && !pp.medicalCleared) return "DeferToWalkPelvic";
+  if (light) return "DeferToWalkPelvic";
+  return "OK";
+}
+
+// Build one training week with two run sessions separated by 48h
+function buildWeek(start, totalRunMinutes) {
+  const per = Math.round(totalRunMinutes / 2);
+  const sessions = [
+    {
+      date: addDays(start, 0),
+      type: "run",
+      minutes: per,
+      rpe: 3,
+      tags: ["#Postpartum", "#ReturnToRun", "RPE3-4"],
+    },
+    {
+      date: addDays(start, 2),
+      type: "run",
+      minutes: per,
+      rpe: 3,
+      tags: ["#Postpartum", "#ReturnToRun", "RPE3-4"],
+    },
+  ];
+  return { start, sessions, totalRunMinutes: per * 2 };
+}
+
+function createPlan(start, startingTotal) {
+  const weeks = [];
+  let total = startingTotal;
+  for (let i = 0; i < 4; i++) {
+    const wStart = addDays(start, i * 7);
+    weeks.push(buildWeek(wStart, total));
+    total = Math.round(total * 1.1); // +10%
+  }
+  return weeks;
+}
+
+function createWalkPelvicPlan(start, weeks = 2) {
+  const plan = [];
+  for (let i = 0; i < weeks; i++) {
+    const wStart = addDays(start, i * 7);
+    const sessions = [
+      { date: addDays(wStart, 0), type: "walk", minutes: 30 },
+      { date: addDays(wStart, 2), type: "pelvic", minutes: 0 },
+    ];
+    plan.push({ start: wStart, sessions, totalRunMinutes: 0 });
+  }
+  return plan;
+}
+
+/**
+ * Generate a postpartum running plan.
+ * @param {Object} pp - profile
+ * @param {Date} start - starting date
+ * @returns {Object} plan
+ */
+function generatePostpartumPlan(pp, start) {
+  const status = evaluateReadiness(pp);
+  if (status === "Stop") return { status, weeks: [] };
+  if (status === "DeferToWalkPelvic") {
+    return { status: "Defer", weeks: createWalkPelvicPlan(start) };
+  }
+  if (pp.weeksPostpartum < 12) {
+    return { status: "OK", weeks: createPlan(start, 20) }; // phase2-like
+  }
+  // phase3
+  const startTotal = pp.goal === "run_30min" ? 40 : 20;
+  return { status: "OK", weeks: createPlan(start, startTotal) };
+}
+
+/**
+ * Regress the plan if symptoms appear.
+ * Repeats previous week with -10% volume then continues progression.
+ * @param {Object} plan
+ * @param {number} weekNumber - 1-based week index to adjust from
+ * @returns {Object} updated plan
+ */
+function applySymptoms(plan, weekNumber) {
+  const idx = weekNumber - 1;
+  if (!plan?.weeks || idx <= 0 || idx >= plan.weeks.length) return plan;
+  const prev = plan.weeks[idx - 1].totalRunMinutes;
+  let total = Math.round(prev * 0.9);
+  for (let i = idx; i < plan.weeks.length; i++) {
+    const start = plan.weeks[i].start;
+    plan.weeks[i] = buildWeek(start, total);
+    total = Math.round(total * 1.1);
+  }
+  return plan;
+}
+
+module.exports = { evaluateReadiness, generatePostpartumPlan, applySymptoms };

--- a/test/postpartumPlan.test.js
+++ b/test/postpartumPlan.test.js
@@ -1,0 +1,87 @@
+const { expect } = require('chai');
+const { generatePostpartumPlan, applySymptoms } = require('../postpartum');
+
+describe('postpartum plan generator', () => {
+  it('6 weeks with medical clearance -> running plan phase2', () => {
+    const profile = {
+      enabled: true,
+      weeksPostpartum: 6,
+      deliveryType: 'vaginal',
+      symptoms: {
+        leakage: false,
+        heaviness: false,
+        painAbdominalBack: false,
+        diastasisSuspected: false,
+        incisionPain: false,
+        abnormalBleeding: false,
+      },
+      activityLevel: 'sedentary',
+      goal: 'run_5k_comfort',
+      medicalCleared: true,
+    };
+    const start = new Date('2024-01-01');
+    const plan = generatePostpartumPlan(profile, start);
+    expect(plan.status).to.equal('OK');
+    expect(plan.weeks[0].sessions).to.have.lengthOf(2);
+    const [s1, s2] = plan.weeks[0].sessions;
+    expect(s1.rpe).to.be.within(3, 4);
+    expect(s2.rpe).to.be.within(3, 4);
+    const diffDays = (s2.date - s1.date) / (1000 * 60 * 60 * 24);
+    expect(diffDays).to.be.at.least(2); // 48h rest
+    for (let i = 1; i < plan.weeks.length; i++) {
+      const prev = plan.weeks[i - 1].totalRunMinutes;
+      const curr = plan.weeks[i].totalRunMinutes;
+      expect(curr).to.be.at.most(prev * 1.15 + 0.1);
+    }
+  });
+
+  it('10 weeks without medical clearance -> walk + pelvic plan', () => {
+    const profile = {
+      enabled: true,
+      weeksPostpartum: 10,
+      deliveryType: 'vaginal',
+      symptoms: {
+        leakage: false,
+        heaviness: false,
+        painAbdominalBack: false,
+        diastasisSuspected: false,
+        incisionPain: false,
+        abnormalBleeding: false,
+      },
+      activityLevel: 'sedentary',
+      goal: 'run_5k_comfort',
+      medicalCleared: false,
+    };
+    const start = new Date('2024-01-01');
+    const plan = generatePostpartumPlan(profile, start);
+    expect(plan.status).to.equal('Defer');
+    expect(plan.weeks).to.have.lengthOf(2);
+    expect(plan.weeks[0].sessions[0].type).to.equal('walk');
+  });
+
+  it('symptom feedback regresses next weeks by -10%', () => {
+    const profile = {
+      enabled: true,
+      weeksPostpartum: 16,
+      deliveryType: 'vaginal',
+      symptoms: {
+        leakage: false,
+        heaviness: false,
+        painAbdominalBack: false,
+        diastasisSuspected: false,
+        incisionPain: false,
+        abnormalBleeding: false,
+      },
+      activityLevel: 'sedentary',
+      goal: 'run_30min',
+      medicalCleared: true,
+    };
+    const start = new Date('2024-01-01');
+    const plan = generatePostpartumPlan(profile, start);
+    const firstWeek = plan.weeks[0].totalRunMinutes;
+    applySymptoms(plan, 2); // symptoms after week1 session2 -> adjust from week2
+    expect(plan.weeks[1].totalRunMinutes).to.be.closeTo(firstWeek * 0.9, 0.1);
+    const diffDays = (plan.weeks[1].sessions[1].date - plan.weeks[1].sessions[0].date) / (1000 * 60 * 60 * 24);
+    expect(diffDays).to.be.at.least(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add utilities to generate postpartum return-to-run plans with readiness checks
- regress plan automatically when symptoms are reported
- cover postpartum scenarios with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979e1420b4832baeed41a0f34ac4fb