### PR TITLE
feat: add basic voice coach modules

### DIFF
--- a/src/coach/coachEngine.ts
+++ b/src/coach/coachEngine.ts
@@ -1,0 +1,59 @@
+import { getState } from '../state/runState';
+import { shouldSpeak } from './cooldown';
+import { getMessage } from './messages';
+import { speak } from './tts';
+
+let timer: any;
+
+/**
+ * Starts the coaching evaluation loop.
+ * The loop runs every 5 seconds and evaluates the current run state,
+ * emitting voice messages when appropriate.
+ */
+export function startEngine(lang: 'fr' | 'en' = 'fr') {
+  if (timer) return;
+  const s = getState();
+  speak(getMessage('start_brief', lang, s.vars), lang);
+
+  timer = setInterval(() => {
+    const st = getState();
+
+    if (st.split_due && shouldSpeak('split', 45)) {
+      speak(getMessage('split', lang, st.vars), lang);
+    }
+
+    // Pace difference
+    if (st.pace_diff >= 20 && st.diff_duration >= 120 && shouldSpeak('pace_fast', 45)) {
+      speak(getMessage('pace_fast', lang, st.vars), lang);
+    } else if (st.pace_diff <= -20 && st.diff_duration >= 120 && shouldSpeak('pace_slow', 45)) {
+      speak(getMessage('pace_slow', lang, st.vars), lang);
+    }
+
+    // Fatigue detection
+    if (st.is_fatigue && shouldSpeak('fatigue', 90)) {
+      speak(getMessage('fatigue', lang, st.vars), lang);
+    }
+
+    // Terrain messages
+    if (st.elev_grad > 3 && shouldSpeak('hill_up', 60)) {
+      speak(getMessage('hill_up', lang, st.vars), lang);
+    } else if (st.elev_grad < -3 && shouldSpeak('hill_down', 60)) {
+      speak(getMessage('hill_down', lang, st.vars), lang);
+    }
+
+    // Hydration reminders
+    if (st.hydration_due && shouldSpeak('hydration', 600)) {
+      speak(getMessage('hydration', lang, st.vars), lang);
+    }
+
+    // Final kick
+    if (st.in_final_km && st.ok_for_kick && shouldSpeak('final_km', 60)) {
+      speak(getMessage('final_km', lang, st.vars), lang);
+    }
+  }, 5000);
+}
+
+export function stopEngine() {
+  if (timer) clearInterval(timer);
+  timer = null;
+}

--- a/src/coach/cooldown.ts
+++ b/src/coach/cooldown.ts
@@ -1,0 +1,33 @@
+// Simple cooldown manager to prevent repeated voice prompts
+// Maintains last time a key spoke and enforces a minimum interval
+
+const lastSpoken: Record<string, number> = {};
+
+/**
+ * Returns true if the key is allowed to speak based on the cooldown.
+ * When true, the timestamp is updated. When false, the cooldown is still active.
+ * @param key Identifier of the message category
+ * @param seconds Cooldown duration in seconds
+ */
+export function shouldSpeak(key: string, seconds: number): boolean {
+  const now = Date.now();
+  const last = lastSpoken[key] ?? 0;
+  if (now - last >= seconds * 1000) {
+    lastSpoken[key] = now;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Resets cooldowns. Passing a key resets only that entry; otherwise all are cleared.
+ */
+export function resetCooldown(key?: string) {
+  if (key) {
+    delete lastSpoken[key];
+  } else {
+    Object.keys(lastSpoken).forEach(k => delete lastSpoken[k]);
+  }
+}
+
+export const _debug = { lastSpoken };

--- a/src/coach/index.ts
+++ b/src/coach/index.ts
@@ -1,0 +1,28 @@
+import { startEngine, stopEngine } from './coachEngine';
+import { stop as stopTTS } from './tts';
+
+/**
+ * Starts the voice coach.
+ */
+export function startCoach(lang: 'fr' | 'en' = 'fr') {
+  startEngine(lang);
+}
+
+/**
+ * Stops the coach, TTS and attempts to shut down background GPS tracking.
+ */
+export function stopCoach() {
+  stopEngine();
+  stopTTS();
+
+  // Attempt to stop Capacitor background geolocation if available
+  const bg: any = (globalThis as any).BackgroundGeolocation;
+  bg?.stop?.();
+  bg?.removeAllListeners?.();
+
+  // Clear standard geolocation watches if a watchId is stored globally
+  const watchId: any = (globalThis as any).__geoWatchId;
+  if (typeof watchId === 'number' && globalThis.navigator?.geolocation) {
+    globalThis.navigator.geolocation.clearWatch(watchId);
+  }
+}

--- a/src/coach/messages.ts
+++ b/src/coach/messages.ts
@@ -1,0 +1,44 @@
+// Dictionary of coach messages with simple variable interpolation.
+// Supports French and English languages.
+
+export const messages: Record<'fr' | 'en', Record<string, string>> = {
+  fr: {
+    start_brief: "Objectif: {distance_target} à {pace_target}/km. On démarre tranquille 500 m.",
+    warmup: "On chauffe: vise {pace_warmup}/km, respire 3-3.",
+    pace_fast: "Un poil rapide. Relâche d’environ 2 %.",
+    pace_slow: "Contrôlé. Stabilise ton effort, c’est parfait.",
+    split: "{km} km, moyenne {pace_avg}/km. Tu es {delta_vs_target} vs l’objectif.",
+    fatigue: "On allège 60 s, puis on repart propre. Regarde 10 m devant.",
+    hill_up: "Montée: raccourcis un peu la foulée, garde l’effort.",
+    hill_down: "Descente: laisse aller sans talonner.",
+    hydration: "Prends quelques gorgées maintenant.",
+    final_km: "Dernier km. Si tu as du jus: +5 s/km, épaules basses.",
+    debrief: "Bravo! {distance} km en {time_total}, moy {pace_avg}/km."
+  },
+  en: {
+    start_brief: "Goal: {distance_target} at {pace_target}/km. Easy first 500 m.",
+    warmup: "Warming up: aim {pace_warmup}/km, breathe 3-3.",
+    pace_fast: "A bit quick. Ease off about 2%.",
+    pace_slow: "Controlled. Hold steady, that's great.",
+    split: "{km} km, average {pace_avg}/km. You are {delta_vs_target} vs target.",
+    fatigue: "Back off for 60 s, then build cleanly. Look 10 m ahead.",
+    hill_up: "Hill: shorten your stride, keep the effort.",
+    hill_down: "Downhill: let it roll without heel striking.",
+    hydration: "Take a few sips now.",
+    final_km: "Final km. If you can: +5 s/km, keep shoulders low.",
+    debrief: "Well done! {distance} km in {time_total}, avg {pace_avg}/km."
+  }
+};
+
+/**
+ * Returns a formatted message for the given key and language.
+ * Variables in the message are replaced using values provided in `vars`.
+ */
+export function getMessage(key: string, lang: 'fr' | 'en', vars: Record<string, any> = {}): string {
+  const dict = messages[lang] || messages.fr;
+  const template = dict[key] || '';
+  return template.replace(/\{(.*?)\}/g, (_, v) => {
+    const value = vars[v.trim()];
+    return value !== undefined ? String(value) : '';
+  });
+}

--- a/src/coach/stt.ts
+++ b/src/coach/stt.ts
@@ -1,0 +1,22 @@
+// Placeholder for speech-to-text command recognition.
+// Actual implementation can use native APIs or Web Speech later.
+
+type CommandCallback = (command: string) => void;
+let callback: CommandCallback | null = null;
+
+export async function init() {
+  // future initialization for native speech recognition
+}
+
+export function onCommand(cb: CommandCallback) {
+  callback = cb;
+}
+
+export function dispose() {
+  callback = null;
+}
+
+// Utility to trigger a command manually (useful for tests or mocks)
+export function _emit(command: string) {
+  callback?.(command);
+}

--- a/src/coach/tts.ts
+++ b/src/coach/tts.ts
@@ -1,0 +1,53 @@
+// Minimal text-to-speech wrapper with queue handling.
+// Uses the Web Speech API when available; otherwise falls back to console logs.
+
+let speaking = false;
+const queue: { text: string; lang: 'fr' | 'en' }[] = [];
+
+function nativeSpeak(text: string, lang: 'fr' | 'en'): Promise<void> {
+  // Browser environment
+  if (typeof window !== 'undefined' && (window as any).speechSynthesis) {
+    return new Promise(resolve => {
+      const utter = new SpeechSynthesisUtterance(text);
+      utter.lang = lang === 'fr' ? 'fr-FR' : 'en-US';
+      utter.onend = () => resolve();
+      (window as any).speechSynthesis.speak(utter);
+    });
+  }
+  // Node or unsupported environment: log and resolve immediately
+  console.log(`[TTS:${lang}] ${text}`);
+  return Promise.resolve();
+}
+
+function nativeStop() {
+  if (typeof window !== 'undefined' && (window as any).speechSynthesis) {
+    (window as any).speechSynthesis.cancel();
+  }
+}
+
+/**
+ * Enqueue text to be spoken. A basic deduplication prevents repeated messages.
+ */
+export async function speak(text: string, lang: 'fr' | 'en') {
+  const last = queue[queue.length - 1];
+  if (last && last.text === text) return; // dedupe consecutive
+  queue.push({ text, lang });
+  if (speaking) return;
+  speaking = true;
+  while (queue.length) {
+    const item = queue.shift()!;
+    await nativeSpeak(item.text, item.lang);
+  }
+  speaking = false;
+}
+
+/**
+ * Stops current speech and clears the queue.
+ */
+export function stop() {
+  queue.length = 0;
+  nativeStop();
+  speaking = false;
+}
+
+export const _debug = { queue };

--- a/src/state/runState.ts
+++ b/src/state/runState.ts
@@ -1,0 +1,60 @@
+// Minimal run state store for the coaching engine.
+// In a real application this would be driven by sensors and user input.
+
+export interface RunState {
+  pace_now: number; // seconds per km
+  pace_avg: number;
+  pace_target: number;
+  distance_km: number;
+  split_due: boolean;
+  pace_diff: number; // difference vs target in s/km
+  diff_duration: number; // seconds the diff has persisted
+  is_fatigue: boolean;
+  elev_grad: number; // grade percentage
+  hydration_due: boolean;
+  in_final_km: boolean;
+  ok_for_kick: boolean;
+  vars: Record<string, any>; // variables for message templates
+}
+
+const state: RunState = {
+  pace_now: 0,
+  pace_avg: 0,
+  pace_target: 0,
+  distance_km: 0,
+  split_due: false,
+  pace_diff: 0,
+  diff_duration: 0,
+  is_fatigue: false,
+  elev_grad: 0,
+  hydration_due: false,
+  in_final_km: false,
+  ok_for_kick: false,
+  vars: {}
+};
+
+export function getState(): RunState {
+  return state;
+}
+
+export function setState(partial: Partial<RunState>) {
+  Object.assign(state, partial);
+}
+
+export function resetState() {
+  setState({
+    pace_now: 0,
+    pace_avg: 0,
+    pace_target: 0,
+    distance_km: 0,
+    split_due: false,
+    pace_diff: 0,
+    diff_duration: 0,
+    is_fatigue: false,
+    elev_grad: 0,
+    hydration_due: false,
+    in_final_km: false,
+    ok_for_kick: false,
+    vars: {}
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold voice coach engine with periodic evaluation loop
- add text-to-speech wrapper, messages dictionary, and cooldown manager
- expose start/stop coach helpers and simple run state store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2e5c6ea8832ba726a70d4e3f0de3