### PR TITLE
Fix statistics tiles dark mode contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
             --surface-alt2-color: #e9ecef;
             --text-color: var(--dark-color);
             --on-primary-color: #ffffff;
+            --shadow-color: rgba(0,0,0,0.05);
             --spacing: 16px;
         }
 
@@ -47,6 +48,7 @@
                 --text-color: var(--light-color);
                 --muted-color: #bdc3c7;
                 --on-primary-color: #ffffff;
+                --shadow-color: rgba(0,0,0,0.5);
             }
         }
 
@@ -57,6 +59,7 @@
             --surface-alt2-color: #3a3a3a;
             --text-color: var(--light-color);
             --muted-color: #bdc3c7;
+            --shadow-color: rgba(0,0,0,0.5);
         }
 
         body.dark-mode nav button.active {
@@ -65,7 +68,7 @@
         }
 
         body.dark-mode .metric-box {
-            background-color: #2a2a2a;
+            background-color: var(--surface-alt-color);
         }
 
         body.dark-mode .form-control {
@@ -124,7 +127,7 @@
             display: flex;
             justify-content: space-around;
             background-color: var(--surface-color);
-            box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+            box-shadow: 0 2px 5px var(--shadow-color);
             position: fixed;
             bottom: 0;
             left: 0;
@@ -180,7 +183,7 @@
             border-radius: 8px;
             padding: var(--spacing);
             margin-bottom: var(--spacing);
-            box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+            box-shadow: 0 2px 5px var(--shadow-color);
             overflow-x: auto; /* Avoid page overflow on small screens */
         }
         
@@ -253,7 +256,7 @@
             flex: 1;
             text-align: center;
             padding: 10px;
-            background-color: #f8f9fa;
+            background-color: var(--surface-alt-color);
             border-radius: 4px;
             margin: 0 4px;
         }
@@ -276,11 +279,11 @@
         }
         
         .stat-item {
-            background-color: white;
+            background-color: var(--surface-color);
             padding: var(--spacing);
             border-radius: 8px;
             text-align: center;
-            box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+            box-shadow: 0 2px 5px var(--shadow-color);
         }
         
         .stat-value {


### PR DESCRIPTION
## Summary
- use theme variables for statistics tiles and nav/card shadow
- add `--shadow-color` with dark-mode overrides
- unify metric box backgrounds with CSS variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce08deac8832b979ae164c5342e0f