### PR TITLE
Add persistent connection state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 package-lock.json
+
+connection-state.json

--- a/src/state/connections.js
+++ b/src/state/connections.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+
+// Persistent storage for connection and onboarding state.
+// Data is stored in a JSON file at the project root so it can
+// survive across module reloads and application restarts.
+const DATA_FILE = path.join(__dirname, '../../connection-state.json');
+
+let cache = null;
+
+function load() {
+  if (!cache) {
+    try {
+      const txt = fs.readFileSync(DATA_FILE, 'utf8');
+      cache = JSON.parse(txt);
+    } catch (err) {
+      cache = { onboardingSeen: false, stravaConnected: false };
+    }
+  }
+  return cache;
+}
+
+function save() {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(cache));
+}
+
+// Onboarding state -----------------------------------------------------------
+function shouldShowOnboarding() {
+  return !load().onboardingSeen;
+}
+
+function setOnboardingShown() {
+  load();
+  cache.onboardingSeen = true;
+  save();
+}
+
+// Strava connection ----------------------------------------------------------
+function isStravaConnected() {
+  return !!load().stravaConnected;
+}
+
+function connectStrava() {
+  load();
+  cache.stravaConnected = true;
+  save();
+}
+
+function disconnectStrava() {
+  load();
+  cache.stravaConnected = false;
+  save();
+}
+
+// Garmin is not yet available ------------------------------------------------
+function isGarminEnabled() {
+  return false;
+}
+
+// Utility for tests ----------------------------------------------------------
+function resetForTests() {
+  cache = null;
+  if (fs.existsSync(DATA_FILE)) {
+    fs.unlinkSync(DATA_FILE);
+  }
+}
+
+module.exports = {
+  shouldShowOnboarding,
+  setOnboardingShown,
+  isStravaConnected,
+  connectStrava,
+  disconnectStrava,
+  isGarminEnabled,
+  resetForTests,
+  DATA_FILE,
+};

--- a/test/connectionsState.test.js
+++ b/test/connectionsState.test.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+
+const statePath = path.join(__dirname, '..', 'connection-state.json');
+
+function loadFreshModule() {
+  delete require.cache[require.resolve('../src/state/connections')];
+  return require('../src/state/connections');
+}
+
+describe('connection state', () => {
+  beforeEach(() => {
+    if (fs.existsSync(statePath)) {
+      fs.unlinkSync(statePath);
+    }
+  });
+
+  it('shows onboarding only once', () => {
+    let state = loadFreshModule();
+    expect(state.shouldShowOnboarding()).to.be.true;
+    state.setOnboardingShown();
+    expect(state.shouldShowOnboarding()).to.be.false;
+
+    state = loadFreshModule();
+    expect(state.shouldShowOnboarding()).to.be.false;
+  });
+
+  it('persists strava connection', () => {
+    let state = loadFreshModule();
+    expect(state.isStravaConnected()).to.be.false;
+    state.connectStrava();
+    expect(state.isStravaConnected()).to.be.true;
+
+    state = loadFreshModule();
+    expect(state.isStravaConnected()).to.be.true;
+
+    state.disconnectStrava();
+    expect(state.isStravaConnected()).to.be.false;
+  });
+
+  it('garmin is disabled', () => {
+    const state = loadFreshModule();
+    expect(state.isGarminEnabled()).to.be.false;
+  });
+});


### PR DESCRIPTION
## Summary
- track onboarding visibility and Strava connection in a persistent JSON store
- disable Garmin connection and expose helpers for onboarding and Strava OAuth triggers
- cover new behaviour with unit tests and ignore generated state file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf11c8550832ba3d804c277fd303e