### PR TITLE
fix: keep run controls above iOS safe area

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,8 @@
             display: flex;
             justify-content: space-around;
             margin-top: var(--spacing);
+            padding-bottom: calc(var(--spacing) + constant(safe-area-inset-bottom));
+            padding-bottom: calc(var(--spacing) + env(safe-area-inset-bottom));
         }
         
         .big-metric {


### PR DESCRIPTION
## Summary
- add safe-area bottom padding to run controls so Play/Stop stay visible on iOS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf5306488832b8bd77748fab7ec74