### PR TITLE
Fix Leaflet map overlapping bottom tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
             display: flex;
             flex-direction: column;
             touch-action: manipulation;
-            padding-bottom: 60px; /* espace pour la barre de navigation fixe */
+            padding-bottom: calc(56px + env(safe-area-inset-bottom)); /* espace pour la barre de navigation fixe */
         }
 
         h1, h2, h3 {
@@ -152,6 +152,7 @@
         nav {
             display: flex;
             justify-content: space-around;
+            align-items: center;
             background-color: var(--surface-color);
             box-shadow: 0 2px 5px var(--shadow-color);
             position: fixed;
@@ -159,7 +160,17 @@
             left: 0;
             right: 0;
             z-index: 1000;
+            height: 56px;
             padding-bottom: env(safe-area-inset-bottom);
+        }
+
+        ion-tab-bar {
+            --height: 56px;
+            z-index: 1000;
+        }
+
+        ion-content {
+            --padding-bottom: calc(56px + env(safe-area-inset-bottom));
         }
 
         #nav-profile {
@@ -488,6 +499,10 @@
             margin-bottom: var(--spacing);
             border-radius: 8px;
             overflow: hidden;
+        }
+
+        .leaflet-bottom {
+            bottom: calc(56px + env(safe-area-inset-bottom) + 8px);
         }
         
         #run-map {


### PR DESCRIPTION
## Summary
- Ensure consistent 56px tab bar height and matching padding on page content
- Reposition Leaflet controls above the bottom tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf7e8a9a4832baa9a62ed2693c57e