### PR TITLE
chore: remove version label

### DIFF
--- a/index.html
+++ b/index.html
@@ -978,7 +978,6 @@ body.dark-mode .splash-version {
         <i data-lucide="activity" class="runner-icon"></i>
         <div class="runner-track"></div>
         <div class="splash-logo">RunPacer</div>
-        <div class="splash-version">Version 1.12</div>
     </div>
     <div id="onboarding-overlay">
         <div class="onboarding-step" id="onboard-step-1">


### PR DESCRIPTION
## Summary
- remove hardcoded `Version 1.12` label from splash screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cfac5be20832b90a446f68c0bc05a