### PR TITLE
Ensure navigation tabs remain above Leaflet map

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,8 @@
             bottom: 0;
             left: 0;
             right: 0;
-            z-index: 1000;
+            /* Place navigation above interactive map layers */
+            z-index: 2000;
             padding-bottom: env(safe-area-inset-bottom);
         }
 


### PR DESCRIPTION
## Summary
- Keep bottom navigation bar above Leaflet map layers by raising its z-index.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cfb1e5938832b90f886b9e85e1dbe