### PR TITLE
feat: display training day selection in profile as calendar grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -1270,33 +1270,27 @@ body.dark-mode .splash-version {
                     
                     <div class="form-group">
                         <label>Jours d'entraînement préférés</label>
-                        <div>
+                        <div class="days-selection">
                             <input type="checkbox" id="monday" name="training-days">
-                            <label for="monday">Lundi</label>
-                        </div>
-                        <div>
+                            <label for="monday" title="Lundi">Lu</label>
+
                             <input type="checkbox" id="tuesday" name="training-days" checked>
-                            <label for="tuesday">Mardi</label>
-                        </div>
-                        <div>
+                            <label for="tuesday" title="Mardi">Ma</label>
+
                             <input type="checkbox" id="wednesday" name="training-days">
-                            <label for="wednesday">Mercredi</label>
-                        </div>
-                        <div>
+                            <label for="wednesday" title="Mercredi">Me</label>
+
                             <input type="checkbox" id="thursday" name="training-days" checked>
-                            <label for="thursday">Jeudi</label>
-                        </div>
-                        <div>
+                            <label for="thursday" title="Jeudi">Je</label>
+
                             <input type="checkbox" id="friday" name="training-days">
-                            <label for="friday">Vendredi</label>
-                        </div>
-                        <div>
+                            <label for="friday" title="Vendredi">Ve</label>
+
                             <input type="checkbox" id="saturday" name="training-days">
-                            <label for="saturday">Samedi</label>
-                        </div>
-                        <div>
+                            <label for="saturday" title="Samedi">Sa</label>
+
                             <input type="checkbox" id="sunday" name="training-days" checked>
-                            <label for="sunday">Dimanche</label>
+                            <label for="sunday" title="Dimanche">Di</label>
                         </div>
                     </div>
                     


### PR DESCRIPTION
## Summary
- show profile training day options using calendar-style grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2c3d12fc832ba0b7146ade742b80