### PR TITLE
feat: handle Strava callback via Capacitor

### DIFF
--- a/index.html
+++ b/index.html
@@ -4033,6 +4033,7 @@ function loadTrainingPlan() {
             }
         });
     </script>
-    <footer><a href="PRIVACY.md">Politique de confidentialite</a></footer> 
+    <script type="module" src="index.js"></script>
+    <footer><a href="PRIVACY.md">Politique de confidentialite</a></footer>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+import { App } from '@capacitor/app';
+
+App.addListener('appUrlOpen', (event) => {
+  if (event.url && event.url.startsWith('runpacer://')) {
+    const code = new URL(event.url).searchParams.get('code');
+    if (code) {
+      console.log('Strava code reçu:', code);
+      if (window.exchangeStravaCode) {
+        window.exchangeStravaCode(code).catch(err => console.error('Erreur Strava: ' + err.message));
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add Capacitor `appUrlOpen` listener to extract Strava OAuth code
- load new listener module in the HTML entry point

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1bf1ca5f8832bbb5c6467fdb6f34d