### PR TITLE
docs: clarify Strava credential usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ $ xdg-open index.html  # or open the file in your browser of choice
 
 That's it—RunPacer is ready to use.
 
-To enable Strava uploads, set your Strava API client ID and secret in `index.html` and click the link icon in the profile section to authorize the app.
-
+To enable Strava uploads, set your Strava API client ID in `index.html` and click the link icon in the profile section to authorize the app. The Strava client secret is handled server-side, so you don't need to include it in the frontend.
 
 ## Confidentialite
 


### PR DESCRIPTION
## Summary
- clarify that only the Strava client ID is needed on the frontend
- note that the client secret is handled server-side

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75d800c40832ba94ac2d0a10a9856