### PR TITLE
Fix RunpacerConnections reference in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
     <script src="capacitor.js"></script>
     <!-- Connection and onboarding state -->
     <script src="connections.js"></script>
+    <script>
+        window.connections = window.RunpacerConnections;
+    </script>
     <!-- Fonctions utilitaires communes -->
     <script src="utils.js"></script>
     <!-- Plan de reprise postpartum -->


### PR DESCRIPTION
## Summary
- Alias `RunpacerConnections` to `connections` in `index.html` so onboarding and Strava methods resolve

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75d7d3b20832bbfd2e0124bab93e2