### PR TITLE
Fix onboarding helpers and capacitor imports

### DIFF
--- a/connections.js
+++ b/connections.js
@@ -16,6 +16,17 @@
     localStorage.setItem("runPacerConnections", JSON.stringify(obj || {}));
   }
 
+  function shouldShowOnboarding() {
+    const c = getConnections();
+    return !c.onboardingShown;
+  }
+
+  function setOnboardingShown() {
+    const c = getConnections();
+    c.onboardingShown = true;
+    setConnections(c);
+  }
+
   function saveStravaTokens(data) {
     const c = getConnections();
     c.stravaToken = data.access_token;
@@ -137,6 +148,8 @@
     ensureValidToken,
     // utilitaires si besoin
     saveStravaTokens,
-    getConnections
+    getConnections,
+    shouldShowOnboarding,
+    setOnboardingShown
   };
 })();

--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
-import { App } from '@capacitor/app';
-import { Browser } from '@capacitor/browser';
+const App = window.Capacitor?.Plugins?.App;
+const Browser = window.Capacitor?.Plugins?.Browser;
 
-App.addListener('appUrlOpen', async ({ url }) => {
-  if (url?.startsWith('runpacer://')) {
-    try {
-      await Browser.close();
-    } catch (_) {}
-    const code = new URL(url).searchParams.get('code');
-    if (code && window.exchangeCodeOnServer && window.saveTokens) {
-      const tokens = await window.exchangeCodeOnServer(code);
-      window.saveTokens(tokens);
+if (App && Browser) {
+  App.addListener('appUrlOpen', async ({ url }) => {
+    if (url?.startsWith('runpacer://')) {
+      try {
+        await Browser.close();
+      } catch (_) {}
+      const code = new URL(url).searchParams.get('code');
+      if (code && window.exchangeCodeOnServer && window.saveTokens) {
+        const tokens = await window.exchangeCodeOnServer(code);
+        window.saveTokens(tokens);
+      }
     }
-  }
-});
+  });
+}


### PR DESCRIPTION
## Summary
- add onboarding state helpers to exported connections API
- load Capacitor plugins from global rather than bare imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76d9376cc832b996b5730ff686b0f