### PR TITLE
Fix running time tracking to use timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -3509,7 +3509,10 @@ function loadTrainingPlan() {
         
         // Mettre à jour uniquement le temps qui s'écoule
         function updateRunningTime() {
-            currentDuration++;
+            // Calculer la durée écoulée depuis le début de la course
+            if (runStartTimestamp) {
+                currentDuration = Math.floor((Date.now() - runStartTimestamp) / 1000);
+            }
             document.getElementById('duration').textContent = formatTime(currentDuration);
             
             // Annoncer la distance tous les kilomètres (fallback si GPS non disponible)
@@ -3563,6 +3566,8 @@ function loadTrainingPlan() {
         // Fonction pour reprendre la course
         async function resumeRun() {
             isRunning = true;
+            // Ajuster le timestamp de départ pour exclure le temps de pause
+            runStartTimestamp = Date.now() - (currentDuration * 1000);
             runInterval = setInterval(updateRunningTime, 1000);
             await startGpsTracking();
             


### PR DESCRIPTION
## Summary
- calculate duration from start timestamp to prevent lost time when app is backgrounded
- adjust resume logic to maintain correct elapsed time after pause

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68accdf7c0d4832bb791d11a49d1abf4