### PR TITLE
feat: enhance glow card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,13 @@
         }
 
         .card.glow {
-            box-shadow: 0 0 8px var(--secondary-color);
+            background-color: var(--strava-color);
+            box-shadow: 0 0 10px 2px var(--strava-color), 0 0 20px 4px var(--strava-color);
+            color: var(--on-primary-color);
+        }
+
+        .card.glow .card-title {
+            color: var(--on-primary-color);
         }
         
         .card-title {


### PR DESCRIPTION
## Summary
- match glowing card background to orange halo
- intensify glow to be more prominent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adabd85178832bb7f3c1c6f7d87874