### PR TITLE
Gradual 5 km plan progression

### DIFF
--- a/index.html
+++ b/index.html
@@ -1916,7 +1916,14 @@ function generateCustomPlan() {
             
             // Ajuster pour la distance cible
             if (distance === 5) {
-                sessionDistance = Math.min(sessionDistance, 5);
+                // Pour un plan 5 km, démarre plus court et augmente jusqu'à 5 km
+                const startDist = 2; // distance de départ
+                let maxForWeek = 5;
+                if (weeksDiff > 1) {
+                    const weeklyProgress = (5 - startDist) / (weeksDiff - 1);
+                    maxForWeek = startDist + weeklyProgress * (week - 1);
+                }
+                sessionDistance = Math.min(sessionDistance, maxForWeek);
             } else if (distance === 21.1) {
                 // Pour semi-marathon
                 if (type === 'long') {


### PR DESCRIPTION
## Summary
- Start 5 km training plans with shorter distances that build up week by week
- Cap each week's sessions at a dynamically increasing maximum instead of a flat 5 km
- Begin 5 km plans at 2 km to allow a gentler starting point

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7317075c832bb716ff79d99c175e