### PR TITLE
Tailor postpartum plan to activity level

### DIFF
--- a/postpartum.js
+++ b/postpartum.js
@@ -26,6 +26,19 @@ function evaluateReadiness(pp) {
   return "OK";
 }
 
+// Determine starting total run minutes based on profile
+function getStartingTotal(pp) {
+  if (pp.goal === "run_30min") return 40;
+  switch (pp.activityLevel) {
+    case "active":
+      return 30;
+    case "moderate":
+      return 25;
+    default:
+      return 20;
+  }
+}
+
 // Build one training week with two run sessions separated by 48h
 function buildWeek(start, totalRunMinutes) {
   const per = Math.round(totalRunMinutes / 2);
@@ -84,11 +97,11 @@ function generatePostpartumPlan(pp, start) {
   if (status === "DeferToWalkPelvic") {
     return { status: "Defer", weeks: createWalkPelvicPlan(start) };
   }
+  const startTotal = getStartingTotal(pp);
   if (pp.weeksPostpartum < 12) {
-    return { status: "OK", weeks: createPlan(start, 20) }; // phase2-like
+    return { status: "OK", weeks: createPlan(start, Math.min(20, startTotal)) }; // phase2-like
   }
   // phase3
-  const startTotal = pp.goal === "run_30min" ? 40 : 20;
   return { status: "OK", weeks: createPlan(start, startTotal) };
 }
 

--- a/test/postpartumPlan.test.js
+++ b/test/postpartumPlan.test.js
@@ -84,4 +84,29 @@ describe('postpartum plan generator', () => {
     const diffDays = (plan.weeks[1].sessions[1].date - plan.weeks[1].sessions[0].date) / (1000 * 60 * 60 * 24);
     expect(diffDays).to.be.at.least(2);
   });
+
+  it('active runner starts with higher initial volume', () => {
+    const profile = {
+      enabled: true,
+      weeksPostpartum: 16,
+      deliveryType: 'vaginal',
+      symptoms: {
+        leakage: false,
+        heaviness: false,
+        painAbdominalBack: false,
+        diastasisSuspected: false,
+        incisionPain: false,
+        abnormalBleeding: false,
+      },
+      activityLevel: 'active',
+      goal: 'run_5k_comfort',
+      medicalCleared: true,
+    };
+    const start = new Date('2024-01-01');
+    const plan = generatePostpartumPlan(profile, start);
+    expect(plan.weeks[0].totalRunMinutes).to.equal(30);
+    const [s1, s2] = plan.weeks[0].sessions;
+    const diffDays = (s2.date - s1.date) / (1000 * 60 * 60 * 24);
+    expect(diffDays).to.be.at.least(2);
+  });
 });


### PR DESCRIPTION
## Summary
- adjust postpartum plan generation based on runner activity level and goal
- cover active runner scenario in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7954a230832bac542b8dee3d80aa