### PR TITLE
Add interval details to postpartum training sessions

### DIFF
--- a/postpartum.js
+++ b/postpartum.js
@@ -39,26 +39,38 @@ function getStartingTotal(pp) {
   }
 }
 
-// Build one training week with two run sessions separated by 48h
+// Default paces (minutes per km)
+const RUN_PACE = 7;
+const REST_PACE = 12;
+
+// Helper to build a session with run/rest intervals
+function buildSession(date, type, runMin, restMin) {
+  const distance = runMin / RUN_PACE + restMin / REST_PACE;
+  return {
+    date,
+    type,
+    runMinutes: runMin,
+    restMinutes: restMin,
+    minutes: runMin + restMin,
+    rpe: 3,
+    distanceKm: Number(distance.toFixed(2)),
+    paceRun: RUN_PACE,
+    paceRest: REST_PACE,
+    tags: ["#Postpartum", "#ReturnToRun", "RPE3-4"],
+  };
+}
+
+// Build one training week with two interval sessions separated by 48h
 function buildWeek(start, totalRunMinutes) {
-  const per = Math.round(totalRunMinutes / 2);
+  const run1 = Math.round(totalRunMinutes * 0.4);
+  const run2 = totalRunMinutes - run1;
+  const rest1 = Math.round(run1 * 0.5);
+  const rest2 = Math.round(run2 * 0.25);
   const sessions = [
-    {
-      date: addDays(start, 0),
-      type: "run",
-      minutes: per,
-      rpe: 3,
-      tags: ["#Postpartum", "#ReturnToRun", "RPE3-4"],
-    },
-    {
-      date: addDays(start, 2),
-      type: "run",
-      minutes: per,
-      rpe: 3,
-      tags: ["#Postpartum", "#ReturnToRun", "RPE3-4"],
-    },
+    buildSession(addDays(start, 0), "interval_easy", run1, rest1),
+    buildSession(addDays(start, 2), "interval_long", run2, rest2),
   ];
-  return { start, sessions, totalRunMinutes: per * 2 };
+  return { start, sessions, totalRunMinutes: run1 + run2 };
 }
 
 function createPlan(start, startingTotal) {

--- a/test/postpartumPlan.test.js
+++ b/test/postpartumPlan.test.js
@@ -26,6 +26,13 @@ describe('postpartum plan generator', () => {
     const [s1, s2] = plan.weeks[0].sessions;
     expect(s1.rpe).to.be.within(3, 4);
     expect(s2.rpe).to.be.within(3, 4);
+    // intervals info
+    expect(s1.distanceKm).to.be.a('number');
+    expect(s2.distanceKm).to.be.a('number');
+    expect(s1.distanceKm).to.not.equal(s2.distanceKm); // varying distances
+    expect(s1.runMinutes).to.be.gt(0);
+    expect(s1.restMinutes).to.be.gt(0);
+    expect(s1.paceRun).to.be.lt(s1.paceRest); // run faster than rest
     const diffDays = (s2.date - s1.date) / (1000 * 60 * 60 * 24);
     expect(diffDays).to.be.at.least(2); // 48h rest
     for (let i = 1; i < plan.weeks.length; i++) {


### PR DESCRIPTION
## Summary
- Include default run and rest paces and compute distance for each postpartum session
- Split weekly plan into varied interval workouts with run and rest durations
- Extend tests to ensure sessions report distance, paces, and varying run volumes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af12443ae0832bb4d6c0eee54f43d4