### PR TITLE
Fix postpartum calendar run start

### DIFF
--- a/index.html
+++ b/index.html
@@ -2100,6 +2100,7 @@ document.getElementById('plan-event-date').min = new Date(new Date().getTime() +
                     });
                 });
                 userData.trainingPlan = plan;
+                userData.eventDate = res.endDate.toISOString().split('T')[0];
                 updateTrainingPlanDisplay();
                 saveTrainingPlan();
                 return;
@@ -2320,7 +2321,9 @@ function renderTrainingCalendar() {
         cal.appendChild(head);
     });
     const start = new Date(userData.trainingPlan[0].date);
-    const end = new Date(userData.eventDate);
+    const end = userData.eventDate
+        ? new Date(userData.eventDate)
+        : new Date(userData.trainingPlan[userData.trainingPlan.length - 1].date);
     const offset = (start.getDay() + 6) % 7;
     for (let i = 0; i < offset; i++) {
         const empty = document.createElement('div');

--- a/postpartum.js
+++ b/postpartum.js
@@ -98,6 +98,15 @@ function createWalkPelvicPlan(start, weeks = 2) {
   return plan;
 }
 
+// Find the date of the last session in a plan
+function getPlanEndDate(weeks) {
+  if (!weeks || weeks.length === 0) return null;
+  const lastWeek = weeks[weeks.length - 1];
+  const sessions = lastWeek.sessions || [];
+  if (sessions.length === 0) return lastWeek.start;
+  return sessions[sessions.length - 1].date;
+}
+
 /**
  * Generate a postpartum running plan.
  * @param {Object} pp - profile
@@ -107,9 +116,18 @@ function createWalkPelvicPlan(start, weeks = 2) {
 function generatePostpartumPlan(pp, start) {
   const recommendations = GENERAL_RECOMMENDATIONS;
   const status = evaluateReadiness(pp);
-  if (status === "Stop") return { status, weeks: [], warning: "Symptômes nécessitant l'arrêt", recommendations };
+  if (status === "Stop") {
+    return { status, weeks: [], warning: "Symptômes nécessitant l'arrêt", recommendations, endDate: null };
+  }
   if (status === "DeferToWalkPelvic") {
-    return { status: "Defer", weeks: createWalkPelvicPlan(start), warning: "Reprise différée : marche + renforcement pelvien", recommendations };
+    const weeks = createWalkPelvicPlan(start);
+    return {
+      status: "Defer",
+      weeks,
+      warning: "Reprise différée : marche + renforcement pelvien",
+      recommendations,
+      endDate: getPlanEndDate(weeks)
+    };
   }
   const startTotal = getStartingTotal(pp);
   let weeks;
@@ -118,7 +136,7 @@ function generatePostpartumPlan(pp, start) {
   } else {
     weeks = createPlan(start, startTotal);
   }
-  return { status: "OK", weeks, recommendations };
+  return { status: "OK", weeks, recommendations, endDate: getPlanEndDate(weeks) };
 }
 
 /**
@@ -141,7 +159,7 @@ function applySymptoms(plan, weekNumber) {
   return plan;
 }
 
-const api = { evaluateReadiness, generatePostpartumPlan, applySymptoms };
+const api = { evaluateReadiness, generatePostpartumPlan, applySymptoms, getPlanEndDate };
 
 // Support both Node.js and browser environments
 if (typeof module !== 'undefined' && module.exports) {

--- a/test/postpartumPlan.test.js
+++ b/test/postpartumPlan.test.js
@@ -44,6 +44,7 @@ describe('postpartum plan generator', () => {
     const w3 = plan.weeks[2].totalRunMinutes;
     const w4 = plan.weeks[3].totalRunMinutes;
     expect(w4).to.be.closeTo(Math.round(w3 * 0.85), 0.1);
+    expect(plan.endDate.getTime()).to.equal(plan.weeks[3].sessions[1].date.getTime());
   });
 
   it('10 weeks without medical clearance -> walk + pelvic plan', () => {


### PR DESCRIPTION
## Summary
- expose `getPlanEndDate` and include `endDate` in generated postpartum plans
- set `eventDate` when generating postpartum plan and fallback to last session for calendar rendering
- ensure postpartum plan end date is covered by tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af3b6c54b4832b81f27a8b1a4d2c94